### PR TITLE
Give redirects the correct path to the new URL

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,8 +11,8 @@ function plugin (options) {
     if (options.redirect) {
       // Redirect to permalink location
       const redirectBuffer = new Buffer(`
-        <meta http-equiv="refresh" content="0; url=/${newFile.permalink}">
-        <link rel="canonical" href="/${newFile.permalink}" />
+        <meta http-equiv="refresh" content="0; url=/${file.path}">
+        <link rel="canonical" href="/${file.path}" />
       `)
       const orginalBuffer = newFile.contents
       newFile.contents = Buffer.concat([redirectBuffer, orginalBuffer])


### PR DESCRIPTION
Hello,

I found when I tried to use redirects with the following parameters:

 .use(aliases({redirect:true}))

...it correctly adds the metatags but they are all set to "undefined".

This pull request puts the correct URL of the new post allowing the redirects to function as intended.

PS. I'm unsure why the last line of the file was flagged as changed by git. If you have any insight, I'm glad to hear it. Perhaps it is why it requests a newline at the end of the file.

Thanks for this plugin!